### PR TITLE
Get SQS name from output. Bump component versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ In the above diagram, you can see the components and their relations.
 | <a name="input_s3_expiration_days"></a> [s3\_expiration\_days](#input\_s3\_expiration\_days) | How many days keep log files in S3 bucket. | `number` | `7` | no |
 | <a name="input_s3_force_destroy"></a> [s3\_force\_destroy](#input\_s3\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket first to destroy the bucket without error. | `bool` | `false` | no |
 | <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Secret which contains `vector_username` and `vector_password` we are using to perform Basic Authenification in OpenSearch (ElasticSearch). | `string` | `null` | no |
-| <a name="input_sqs_name"></a> [sqs\_name](#input\_sqs\_name) | By default SQS name generates as `$var.name-$var.eks_cluster_name`. You can override it here by providing custom name. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -105,4 +104,5 @@ In the above diagram, you can see the components and their relations.
 | <a name="output_vector_agent_role"></a> [vector\_agent\_role](#output\_vector\_agent\_role) | IAM Role ARN created for Vector agent |
 | <a name="output_vector_aggregator_role"></a> [vector\_aggregator\_role](#output\_vector\_aggregator\_role) | IAM Role ARN created for Vector aggregator |
 | <a name="output_vector_s3_bucket_id"></a> [vector\_s3\_bucket\_id](#output\_vector\_s3\_bucket\_id) | S3 bucket created to store logs before they parsed |
+| <a name="output_vector_sqs_name"></a> [vector\_sqs\_name](#output\_vector\_sqs\_name) | SQS created to collect events from S3 and pass to vector aggregator |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "vector_aggregator_role" {
   description = "IAM Role ARN created for Vector aggregator"
   value       = module.vector_aggregator_role.iam_role_arn
 }
+
+output "vector_sqs_name" {
+  description = "SQS created to collect events from S3 and pass to vector aggregator"
+  value       = module.vector_sqs.queue_name
+}

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,5 +1,5 @@
 locals {
-  sqs_name = coalesce(var.sqs_name, lower("${var.name}-${var.eks_cluster_name}"))
+  sqs_name = lower("${var.name}-${var.eks_cluster_name}")
 }
 
 module "vector_sqs" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,9 +91,3 @@ variable "s3_bucket_name" {
   default     = null
   description = "By default S3 bucket name generates as `$var.name-$var.eks_cluster_name-logs`. You can override it here by providing custom name."
 }
-
-variable "sqs_name" {
-  type        = string
-  default     = null
-  description = "By default SQS name generates as `$var.name-$var.eks_cluster_name`. You can override it here by providing custom name."
-}


### PR DESCRIPTION
Need to get the SQS name to configure a CloudWatch Alarm for stuck events if something goes wrong with the vector-aggregator. There are several approaches:

- ~~Pass the already created SQS to this module.~~
- Get the name of configured resources from the output of this module.
- ~~Pass the name of the SQS and use the same in the CloudWatch Alarm.~~

